### PR TITLE
プロフィールとスキルセクションの更新: UI/UXエンジニアの表記追加とCursorスキルの追加

### DIFF
--- a/src/app/pages/About.jsx
+++ b/src/app/pages/About.jsx
@@ -15,7 +15,7 @@ export default function About() {
         <ProfileWrapper>
           <ImageArea><Image src={profile.image.url} /></ImageArea>
           <div>
-            <p>UI/フロントエンド エンジニア</p>
+            <p>UI/UX フロントエンド エンジニア</p>
             <p>ナカバヤシ リリキ</p>
           </div>
         </ProfileWrapper>
@@ -25,7 +25,7 @@ export default function About() {
         <p>FE: HTML, CSS, SASS, JavaScript(ES6), React, Vue.js, Angular, TypeScript</p>
         <p>BE: Node.js, Java, PHP, Ruby</p>
         <p>DB: MySQL, PostgreSQL, mongoDB</p>
-        <p>ETC.: Firebase, Wordpress</p>
+        <p>ETC.: Cursor, Firebase, Wordpress</p>
         <br />
         <p>勉強中: UI, Webデザイン, SVELTE</p>
       </BasicWrapper>


### PR DESCRIPTION
## 関連issue
#1 

## 変更内容
- プロフィールセクションの職種を「UI/UX フロントエンド エンジニア」に更新
- スキルセクションのETC.に「Cursor」を追加

## 変更理由
- より正確な職種の表現に更新
- 新たに習得したスキルの追加

## 影響範囲
- src/app/pages/About.jsx のみの変更
- 既存の機能への影響なし

## 動作確認
- [x] プロフィールセクションの表示確認
- [x] スキルセクションの表示確認

> <div align="right"><i>Closes #1</i></div>