### PR TITLE
Skillセクション「勉強中」項目の内容を修正

### DIFF
--- a/src/app/pages/About.jsx
+++ b/src/app/pages/About.jsx
@@ -27,7 +27,7 @@ export default function About() {
         <p>DB: MySQL, PostgreSQL, mongoDB</p>
         <p>ETC.: Firebase, Wordpress</p>
         <br />
-        <p>勉強中: UI, Webデザイン, SVELTE</p>
+        <p>勉強中: UI/UX, Webデザイン, SVELTE, Next.js</p>
       </BasicWrapper>
       <Title>Career</Title>
       <CareerWrapper>


### PR DESCRIPTION
## 変更内容
- Skillセクション「勉強中」の表記を  
  `UI, Webデザイン, SVELTE, Next.js`  
  から  
  `UI/UX, Webデザイン, SVELTE, Next.js`  
  に修正

## 変更理由
- より正確なスキル表現のため

## 影響範囲
- `src/app/pages/About.jsx` のみ

## 動作確認
- [x] Aboutページで「勉強中」項目が正しく表示されることを確認